### PR TITLE
Improve activities dropdown styling

### DIFF
--- a/src/components/ActivitiesMenu.astro
+++ b/src/components/ActivitiesMenu.astro
@@ -41,13 +41,27 @@ const items: Item[] = Object.entries(modules)
   .sort((a, b) => a.label.localeCompare(b.label));
 ---
 <nav class="relative" aria-label="Activities">
-  <details class="inline-block relative">
-    <summary class="list-none cursor-pointer select-none px-3 py-2 border border-ink rounded-md font-semibold">
+  <details class="group inline-block relative">
+    <summary class="flex items-center gap-1 list-none cursor-pointer select-none px-3 py-2 border border-ink rounded-md font-semibold bg-white hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand">
       {label}
+      <svg
+        class="w-3 h-3 transition-transform group-open:rotate-180"
+        viewBox="0 0 10 6"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true">
+        <path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
     </summary>
     <ul class="absolute right-0 mt-2 p-2 border border-soft bg-white rounded-xl min-w-[14rem] shadow-lg z-10">
       {items.map((it) => (
-        <li class="list-none"><a class="block px-2 py-2 no-underline text-inherit rounded-md hover:bg-blue-50 focus:bg-blue-50 outline-none" href={it.url}>{it.label}</a></li>
+        <li class="list-none">
+          <a
+            class="block px-3 py-2 no-underline text-inherit rounded-md hover:bg-soft focus:bg-soft outline-none"
+            href={it.url}
+            >{it.label}</a
+          >
+        </li>
       ))}
     </ul>
   </details>


### PR DESCRIPTION
## Summary
- restyled Activities menu dropdown with chevron icon, hover/focus styles and softer colors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa6ded8f8832489f5d62a78a2ec30