### PR TITLE
feat: add responsive mobile navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^4.3.4",
-        "astro": "^5.13.2"
+        "astro": "^5.13.2",
+        "lucide-astro": "^0.541.0"
       },
       "devDependencies": {
         "@astrojs/tailwind": "^6.0.2",
@@ -3647,6 +3648,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/lucide-astro": {
+      "version": "0.541.0",
+      "resolved": "https://registry.npmjs.org/lucide-astro/-/lucide-astro-0.541.0.tgz",
+      "integrity": "sha512-Xl1Hp4DNDzcvZx6eoa6S9pCiC67ccAC9XHpHtu3cJXnLkgpCc3W6YD/2ZJvpwCG0g0cARmHJKVCdtCbepZmhDw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "astro": ">=2.7.1"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.4",
-    "astro": "^5.13.2"
+    "astro": "^5.13.2",
+    "lucide-astro": "^0.541.0"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.2",

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -38,56 +38,78 @@ const listId = `mobile-${folder}`;
 {
   mobile ? (
     <nav aria-label={label} class="w-full">
-      <div class="flex items-center justify-between">
-        {indexHref ? (
-          <a
-            href={indexHref}
-            class="py-2 font-semibold text-inherit no-underline"
-          >
-            {label}
-          </a>
-        ) : (
-          <span class="py-2 font-semibold">{label}</span>
-        )}
-        {items.length > 0 && (
-          <button
-            id={toggleId}
-            class="p-2"
-            type="button"
-            aria-expanded="false"
-            aria-controls={listId}
-            data-nav-toggle
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+      {items.length > 0 ? (
+        <>
+          <div class="flex items-center gap-2">
+            <button
+              id={toggleId}
+              class="flex flex-1 items-center justify-between py-2 font-semibold"
+              type="button"
+              aria-expanded="false"
+              aria-controls={listId}
+              data-nav-toggle
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </button>
-        )}
-      </div>
-      {items.length > 0 && (
-        <ul id={listId} class="ml-4 hidden flex-col">
-          {items.map((it) => (
-            <li class="list-none">
-              <a
-                class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
-                href={it.url}
+              <span>{label}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
               >
-                {it.label}
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+            {indexHref && (
+              <a
+                href={indexHref}
+                class="p-2 text-inherit no-underline"
+                aria-label={`Go to ${label}`}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M17 8l4 4-4 4m0 0H3m14-4H3"
+                  />
+                </svg>
               </a>
-            </li>
-          ))}
-        </ul>
+            )}
+          </div>
+          <ul id={listId} class="ml-4 hidden flex-col">
+            {items.map((it) => (
+              <li class="list-none">
+                <a
+                  class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
+                  href={it.url}
+                >
+                  {it.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : indexHref ? (
+        <a
+          href={indexHref}
+          class="block py-2 font-semibold text-inherit no-underline"
+        >
+          {label}
+        </a>
+      ) : (
+        <span class="block py-2 font-semibold">{label}</span>
       )}
     </nav>
   ) : (

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -3,19 +3,19 @@ import { getCollection } from "astro:content";
 import { ChevronDown } from "lucide-astro";
 
 interface Item {
-  url: string;
-  label: string;
-  sortIndex: number;
+	url: string;
+	label: string;
+	sortIndex: number;
 }
 
 const {
-  label,
-  folder,
-  mobile = false,
+	label,
+	folder,
+	mobile = false,
 } = Astro.props as {
-  label: string;
-  folder: string;
-  mobile?: boolean;
+	label: string;
+	folder: string;
+	mobile?: boolean;
 };
 
 const pages = await getCollection("pages", (e) => e.id.startsWith(`${folder}`));
@@ -24,102 +24,104 @@ const indexEntry = pages.find((page) => page.id === folder);
 const indexHref = indexEntry ? `/${folder}/` : undefined;
 
 const items: Item[] = pages
-  .filter((page) => page.id !== folder)
-  .map((page) => ({
-    url: `/${page.id}/`,
-    label: page.data.title,
-    sortIndex: page.data.sortIndex,
-  }))
-  .sort((a, b) => a.sortIndex - b.sortIndex);
+	//   .filter((page) => page.id !== folder)
+	.map((page) => ({
+		url: `/${page.id}/`,
+		label: page.data.title,
+		sortIndex: page.data.sortIndex,
+	}))
+	.sort((a, b) => a.sortIndex - b.sortIndex);
 
 const listId = `mobile-${folder}`;
 ---
 
 {
-  mobile ? (
-    <nav aria-label={label} class="w-full">
-      {items.length > 0 ? (
-        <>
-          <div class="flex items-center gap-2">
-            {indexHref ? (
-              <a
-                href={indexHref}
-                class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft"
-              >
-                {label}
-              </a>
-            ) : (
-              <span class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold">
-                {label}
-              </span>
-            )}
-            <button
-              class="p-2"
-              type="button"
-              aria-expanded="false"
-              aria-controls={listId}
-              data-nav-toggle
-              aria-label={`Toggle ${label} menu`}
-            >
-              <ChevronDown class="h-5 w-5" />
-            </button>
-          </div>
-          <ul id={listId} class="ml-4 hidden flex-col">
-            {items.map((it) => (
-              <li class="list-none">
-                <a
-                  class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
-                  href={it.url}
-                >
-                  {it.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </>
-      ) : indexHref ? (
-        <a
-          href={indexHref}
-          class="block py-2 font-semibold text-inherit no-underline hover:bg-soft"
-        >
-          {label}
-        </a>
-      ) : (
-        <span class="block py-2 font-semibold">{label}</span>
-      )}
-    </nav>
-  ) : (
-    <nav class="relative" aria-label={label}>
-      <div class="group relative inline-flex items-center gap-1">
-        {indexHref ? (
-          <a
-            href={indexHref}
-            class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
-          >
-            {label}
-          </a>
-        ) : (
-          <span class="rounded-md px-3 py-2 font-semibold">{label}</span>
-        )}
+	mobile ? (
+		<nav aria-label={label} class="w-full">
+			{items.length > 0 ? (
+				<>
+					<div class="flex items-center gap-2">
+						{indexHref ? (
+							<a
+								href={indexHref}
+								class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft"
+							>
+								{label}
+							</a>
+						) : (
+							<span class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold">
+								{label}
+							</span>
+						)}
+						<button
+							class="p-2"
+							type="button"
+							aria-expanded="false"
+							aria-controls={listId}
+							data-nav-toggle
+							aria-label={`Toggle ${label} menu`}
+						>
+							<ChevronDown class="h-5 w-5" />
+						</button>
+					</div>
+					<ul id={listId} class="ml-4 hidden flex-col">
+						{items.map((it) => (
+							<li class="list-none">
+								<a
+									class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
+									href={it.url}
+								>
+									{it.label}
+								</a>
+							</li>
+						))}
+					</ul>
+				</>
+			) : indexHref ? (
+				<a
+					href={indexHref}
+					class="block py-2 font-semibold text-inherit no-underline hover:bg-soft"
+				>
+					{label}
+				</a>
+			) : (
+				<span class="block py-2 font-semibold">{label}</span>
+			)}
+		</nav>
+	) : (
+		<nav class="relative" aria-label={label}>
+			<div class="group relative inline-flex items-center gap-1">
+				{indexHref ? (
+					<a
+						href={indexHref}
+						class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+					>
+						{label}
+					</a>
+				) : (
+					<span class="rounded-md px-3 py-2 font-semibold">
+						{label}
+					</span>
+				)}
 
-        {items.length > 0 && (
-          <ul
-            id={`menu-${folder}`}
-            class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
-          >
-            {items.map((it) => (
-              <li class="list-none">
-                <a
-                  class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
-                  href={it.url}
-                >
-                  {it.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </nav>
-  )
+				{items.length > 0 && (
+					<ul
+						id={`menu-${folder}`}
+						class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
+					>
+						{items.map((it) => (
+							<li class="list-none">
+								<a
+									class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
+									href={it.url}
+								>
+									{it.label}
+								</a>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</nav>
+	)
 }

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -3,19 +3,19 @@ import { getCollection } from "astro:content";
 import { ChevronDown } from "lucide-astro";
 
 interface Item {
-	url: string;
-	label: string;
-	sortIndex: number;
+  url: string;
+  label: string;
+  sortIndex: number;
 }
 
 const {
-	label,
-	folder,
-	mobile = false,
+  label,
+  folder,
+  mobile = false,
 } = Astro.props as {
-	label: string;
-	folder: string;
-	mobile?: boolean;
+  label: string;
+  folder: string;
+  mobile?: boolean;
 };
 
 const pages = await getCollection("pages", (e) => e.id.startsWith(`${folder}`));
@@ -24,104 +24,102 @@ const indexEntry = pages.find((page) => page.id === folder);
 const indexHref = indexEntry ? `/${folder}/` : undefined;
 
 const items: Item[] = pages
-	//   .filter((page) => page.id !== folder)
-	.map((page) => ({
-		url: `/${page.id}/`,
-		label: page.data.title,
-		sortIndex: page.data.sortIndex,
-	}))
-	.sort((a, b) => a.sortIndex - b.sortIndex);
+  //   .filter((page) => page.id !== folder)
+  .map((page) => ({
+    url: `/${page.id}/`,
+    label: page.data.title,
+    sortIndex: page.data.sortIndex,
+  }))
+  .sort((a, b) => a.sortIndex - b.sortIndex);
 
 const listId = `mobile-${folder}`;
 ---
 
 {
-	mobile ? (
-		<nav aria-label={label} class="w-full">
-			{items.length > 0 ? (
-				<>
-					<div class="flex items-center gap-2">
-						{indexHref ? (
-							<a
-								href={indexHref}
-								class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft"
-							>
-								{label}
-							</a>
-						) : (
-							<span class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold">
-								{label}
-							</span>
-						)}
-						<button
-							class="p-2"
-							type="button"
-							aria-expanded="false"
-							aria-controls={listId}
-							data-nav-toggle
-							aria-label={`Toggle ${label} menu`}
-						>
-							<ChevronDown class="h-5 w-5" />
-						</button>
-					</div>
-					<ul id={listId} class="ml-4 hidden flex-col">
-						{items.map((it) => (
-							<li class="list-none">
-								<a
-									class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
-									href={it.url}
-								>
-									{it.label}
-								</a>
-							</li>
-						))}
-					</ul>
-				</>
-			) : indexHref ? (
-				<a
-					href={indexHref}
-					class="block py-2 font-semibold text-inherit no-underline hover:bg-soft"
-				>
-					{label}
-				</a>
-			) : (
-				<span class="block py-2 font-semibold">{label}</span>
-			)}
-		</nav>
-	) : (
-		<nav class="relative" aria-label={label}>
-			<div class="group relative inline-flex items-center gap-1">
-				{indexHref ? (
-					<a
-						href={indexHref}
-						class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
-					>
-						{label}
-					</a>
-				) : (
-					<span class="rounded-md px-3 py-2 font-semibold">
-						{label}
-					</span>
-				)}
+  mobile ? (
+    <nav aria-label={label} class="w-full">
+      {items.length > 0 ? (
+        <>
+          <div class="flex items-center gap-2">
+            {indexHref ? (
+              <a
+                href={indexHref}
+                class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft"
+              >
+                {label}
+              </a>
+            ) : (
+              <span class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold">
+                {label}
+              </span>
+            )}
+            <button
+              class="p-2"
+              type="button"
+              aria-expanded="false"
+              aria-controls={listId}
+              data-nav-toggle
+              aria-label={`Toggle ${label} menu`}
+            >
+              <ChevronDown class="h-5 w-5" />
+            </button>
+          </div>
+          <ul id={listId} class="ml-4 hidden flex-col">
+            {items.map((it) => (
+              <li class="list-none">
+                <a
+                  class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
+                  href={it.url}
+                >
+                  {it.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : indexHref ? (
+        <a
+          href={indexHref}
+          class="block py-2 font-semibold text-inherit no-underline hover:bg-soft"
+        >
+          {label}
+        </a>
+      ) : (
+        <span class="block py-2 font-semibold">{label}</span>
+      )}
+    </nav>
+  ) : (
+    <nav class="relative" aria-label={label}>
+      <div class="group relative inline-flex items-center gap-1">
+        {indexHref ? (
+          <a
+            href={indexHref}
+            class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+          >
+            {label}
+          </a>
+        ) : (
+          <span class="rounded-md px-3 py-2 font-semibold">{label}</span>
+        )}
 
-				{items.length > 0 && (
-					<ul
-						id={`menu-${folder}`}
-						class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
-					>
-						{items.map((it) => (
-							<li class="list-none">
-								<a
-									class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
-									href={it.url}
-								>
-									{it.label}
-								</a>
-							</li>
-						))}
-					</ul>
-				)}
-			</div>
-		</nav>
-	)
+        {items.length > 0 && (
+          <ul
+            id={`menu-${folder}`}
+            class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
+          >
+            {items.map((it) => (
+              <li class="list-none">
+                <a
+                  class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
+                  href={it.url}
+                >
+                  {it.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </nav>
+  )
 }

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { ArrowRight, ChevronDown } from "lucide-astro";
+import { ChevronDown } from "lucide-astro";
 
 interface Item {
   url: string;
@@ -32,7 +32,6 @@ const items: Item[] = pages
   }))
   .sort((a, b) => a.sortIndex - b.sortIndex);
 
-const toggleId = `toggle-${folder}`;
 const listId = `mobile-${folder}`;
 ---
 
@@ -42,26 +41,28 @@ const listId = `mobile-${folder}`;
       {items.length > 0 ? (
         <>
           <div class="flex items-center gap-2">
+            {indexHref ? (
+              <a
+                href={indexHref}
+                class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft"
+              >
+                {label}
+              </a>
+            ) : (
+              <span class="flex flex-1 items-center rounded-md px-3 py-2 font-semibold">
+                {label}
+              </span>
+            )}
             <button
-              id={toggleId}
-              class="flex flex-1 items-center justify-between py-2 font-semibold"
+              class="p-2"
               type="button"
               aria-expanded="false"
               aria-controls={listId}
               data-nav-toggle
+              aria-label={`Toggle ${label} menu`}
             >
-              <span>{label}</span>
               <ChevronDown class="h-5 w-5" />
             </button>
-            {indexHref && (
-              <a
-                href={indexHref}
-                class="p-2 text-inherit no-underline"
-                aria-label={`Go to ${label}`}
-              >
-                <ArrowRight class="h-5 w-5" />
-              </a>
-            )}
           </div>
           <ul id={listId} class="ml-4 hidden flex-col">
             {items.map((it) => (
@@ -79,7 +80,7 @@ const listId = `mobile-${folder}`;
       ) : indexHref ? (
         <a
           href={indexHref}
-          class="block py-2 font-semibold text-inherit no-underline"
+          class="block py-2 font-semibold text-inherit no-underline hover:bg-soft"
         >
           {label}
         </a>

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -7,7 +7,11 @@ interface Item {
   sortIndex: number;
 }
 
-const { label, folder, mobile = false } = Astro.props as {
+const {
+  label,
+  folder,
+  mobile = false,
+} = Astro.props as {
   label: string;
   folder: string;
   mobile?: boolean;
@@ -31,89 +35,52 @@ const toggleId = `toggle-${folder}`;
 const listId = `mobile-${folder}`;
 ---
 
-{mobile ? (
-  <nav aria-label={label} class="w-full">
-    <div class="flex items-center justify-between">
-      {
-        indexHref ? (
-          <a href={indexHref} class="py-2 font-semibold text-inherit no-underline">
+{
+  mobile ? (
+    <nav aria-label={label} class="w-full">
+      <div class="flex items-center justify-between">
+        {indexHref ? (
+          <a
+            href={indexHref}
+            class="py-2 font-semibold text-inherit no-underline"
+          >
             {label}
           </a>
         ) : (
           <span class="py-2 font-semibold">{label}</span>
-        )
-      }
-      {items.length > 0 && (
-        <button
-          id={toggleId}
-          class="p-2"
-          type="button"
-          aria-expanded="false"
-          aria-controls={listId}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
+        )}
+        {items.length > 0 && (
+          <button
+            id={toggleId}
+            class="p-2"
+            type="button"
+            aria-expanded="false"
+            aria-controls={listId}
+            data-nav-toggle
           >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
-      )}
-    </div>
-    {items.length > 0 && (
-      <ul id={listId} class="ml-4 hidden flex-col">
-        {items.map((it) => (
-          <li class="list-none">
-            <a
-              class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
-              href={it.url}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
             >
-              {it.label}
-            </a>
-          </li>
-        ))}
-      </ul>
-    )}
-    <script is:inline>
-      const toggle = document.getElementById("${toggleId}");
-      const list = document.getElementById("${listId}");
-      if (toggle && list) {
-        toggle.addEventListener("click", function () {
-          const expanded = this.getAttribute("aria-expanded") === "true";
-          this.setAttribute("aria-expanded", String(!expanded));
-          list.classList.toggle("hidden", expanded);
-        });
-      }
-    </script>
-  </nav>
-) : (
-  <nav class="relative" aria-label={label}>
-    <div class="group relative inline-flex items-center gap-1">
-      {
-        indexHref ? (
-          <a
-            href={indexHref}
-            class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
-          >
-            {label}
-          </a>
-        ) : (
-          <span class="rounded-md px-3 py-2 font-semibold">{label}</span>
-        )
-      }
-
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
       {items.length > 0 && (
-        <ul
-          id={`menu-${folder}`}
-          class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
-        >
+        <ul id={listId} class="ml-4 hidden flex-col">
           {items.map((it) => (
             <li class="list-none">
               <a
-                class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
+                class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
                 href={it.url}
               >
                 {it.label}
@@ -122,6 +89,39 @@ const listId = `mobile-${folder}`;
           ))}
         </ul>
       )}
-    </div>
-  </nav>
-)}
+    </nav>
+  ) : (
+    <nav class="relative" aria-label={label}>
+      <div class="group relative inline-flex items-center gap-1">
+        {indexHref ? (
+          <a
+            href={indexHref}
+            class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+          >
+            {label}
+          </a>
+        ) : (
+          <span class="rounded-md px-3 py-2 font-semibold">{label}</span>
+        )}
+
+        {items.length > 0 && (
+          <ul
+            id={`menu-${folder}`}
+            class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
+          >
+            {items.map((it) => (
+              <li class="list-none">
+                <a
+                  class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
+                  href={it.url}
+                >
+                  {it.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -7,7 +7,11 @@ interface Item {
   sortIndex: number;
 }
 
-const { label, folder } = Astro.props as { label: string; folder: string };
+const { label, folder, mobile = false } = Astro.props as {
+  label: string;
+  folder: string;
+  mobile?: boolean;
+};
 
 const pages = await getCollection("pages", (e) => e.id.startsWith(`${folder}`));
 
@@ -15,46 +19,109 @@ const indexEntry = pages.find((page) => page.id === folder);
 const indexHref = indexEntry ? `/${folder}/` : undefined;
 
 const items: Item[] = pages
-  // .filter((page) => page.id !== folder) // hide the index page in the dropdown
+  .filter((page) => page.id !== folder)
   .map((page) => ({
     url: `/${page.id}/`,
     label: page.data.title,
     sortIndex: page.data.sortIndex,
   }))
   .sort((a, b) => a.sortIndex - b.sortIndex);
+
+const toggleId = `toggle-${folder}`;
+const listId = `mobile-${folder}`;
 ---
 
-<nav class="relative" aria-label={label}>
-  <div class="group relative inline-flex items-center gap-1">
-    {
-      indexHref ? (
-        <a
-          href={indexHref}
-          class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
-        >
-          {label}
-        </a>
-      ) : (
-        <span class="rounded-md px-3 py-2 font-semibold">{label}</span>
-      )
-    }
-
-    <ul
-      id={`menu-${folder}`}
-      class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
-    >
+{mobile ? (
+  <nav aria-label={label} class="w-full">
+    <div class="flex items-center justify-between">
       {
-        items.map((it) => (
+        indexHref ? (
+          <a href={indexHref} class="py-2 font-semibold text-inherit no-underline">
+            {label}
+          </a>
+        ) : (
+          <span class="py-2 font-semibold">{label}</span>
+        )
+      }
+      {items.length > 0 && (
+        <button
+          id={toggleId}
+          class="p-2"
+          type="button"
+          aria-expanded="false"
+          aria-controls={listId}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      )}
+    </div>
+    {items.length > 0 && (
+      <ul id={listId} class="ml-4 hidden flex-col">
+        {items.map((it) => (
           <li class="list-none">
             <a
-              class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
+              class="block rounded-md px-3 py-2 text-inherit no-underline hover:bg-soft"
               href={it.url}
             >
               {it.label}
             </a>
           </li>
-        ))
+        ))}
+      </ul>
+    )}
+    <script is:inline>
+      const toggle = document.getElementById("${toggleId}");
+      const list = document.getElementById("${listId}");
+      if (toggle && list) {
+        toggle.addEventListener("click", function () {
+          const expanded = this.getAttribute("aria-expanded") === "true";
+          this.setAttribute("aria-expanded", String(!expanded));
+          list.classList.toggle("hidden", expanded);
+        });
       }
-    </ul>
-  </div>
-</nav>
+    </script>
+  </nav>
+) : (
+  <nav class="relative" aria-label={label}>
+    <div class="group relative inline-flex items-center gap-1">
+      {
+        indexHref ? (
+          <a
+            href={indexHref}
+            class="rounded-md px-3 py-2 font-semibold text-inherit no-underline hover:bg-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+          >
+            {label}
+          </a>
+        ) : (
+          <span class="rounded-md px-3 py-2 font-semibold">{label}</span>
+        )
+      }
+
+      {items.length > 0 && (
+        <ul
+          id={`menu-${folder}`}
+          class="absolute right-0 top-full z-20 hidden min-w-[14rem] rounded-xl border border-soft bg-white p-2 shadow-lg group-focus-within:block group-hover:block"
+        >
+          {items.map((it) => (
+            <li class="list-none">
+              <a
+                class="block rounded-md px-3 py-2 text-inherit no-underline outline-none hover:bg-soft focus:bg-soft"
+                href={it.url}
+              >
+                {it.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  </nav>
+)}

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { ArrowRight, ChevronDown } from "lucide-astro";
 
 interface Item {
   url: string;
@@ -50,20 +51,7 @@ const listId = `mobile-${folder}`;
               data-nav-toggle
             >
               <span>{label}</span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
+              <ChevronDown class="h-5 w-5" />
             </button>
             {indexHref && (
               <a
@@ -71,20 +59,7 @@ const listId = `mobile-${folder}`;
                 class="p-2 text-inherit no-underline"
                 aria-label={`Go to ${label}`}
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-5 w-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M17 8l4 4-4 4m0 0H3m14-4H3"
-                  />
-                </svg>
+                <ArrowRight class="h-5 w-5" />
               </a>
             )}
           </div>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,6 +3,7 @@ import { Image } from "astro:assets";
 import { site } from "../data/site";
 import NavMenu from "./NavMenu.astro";
 import logo from "../assets/logo.png";
+import { Menu } from "lucide-astro";
 ---
 
 <nav class="mx-auto flex max-w-[72rem] items-center justify-between px-4 py-2">
@@ -27,19 +28,7 @@ import logo from "../assets/logo.png";
     aria-expanded="false"
     aria-controls="mobile-menu"
   >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class="h-6 w-6"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M4 6h16M4 12h16M4 18h16"></path>
-    </svg>
+    <Menu class="h-6 w-6" />
   </button>
 </nav>
 <div

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -18,7 +18,44 @@ import logo from "../assets/logo.png";
     </div>
   </div>
   <!-- right cluster -->
-  <div class="flex items-center gap-4">
+  <div class="hidden items-center gap-4 md:flex">
     {site.nav.map((it) => <NavMenu label={it.label} folder={it.folder} />)}
   </div>
+  <button
+    id="mobile-menu-button"
+    class="p-2 md:hidden"
+    aria-expanded="false"
+    aria-controls="mobile-menu"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+  </button>
 </nav>
+<div
+  id="mobile-menu"
+  class="hidden flex-col gap-2 border-t border-soft px-4 pb-4 md:hidden"
+>
+  {site.nav.map((it) => <NavMenu mobile label={it.label} folder={it.folder} />)}
+</div>
+<script is:inline>
+  document
+    .getElementById("mobile-menu-button")
+    ?.addEventListener("click", function () {
+      const expanded = this.getAttribute("aria-expanded") === "true";
+      this.setAttribute("aria-expanded", String(!expanded));
+      document
+        .getElementById("mobile-menu")
+        ?.classList.toggle("hidden", expanded);
+    });
+</script>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -27,6 +27,7 @@ import { Menu } from "lucide-astro";
     class="p-2 md:hidden"
     aria-expanded="false"
     aria-controls="mobile-menu"
+    aria-label="Open navigation menu"
   >
     <Menu class="h-6 w-6" />
   </button>
@@ -43,6 +44,10 @@ import { Menu } from "lucide-astro";
     ?.addEventListener("click", function () {
       const expanded = this.getAttribute("aria-expanded") === "true";
       this.setAttribute("aria-expanded", String(!expanded));
+      this.setAttribute(
+        "aria-label",
+        expanded ? "Open navigation menu" : "Close navigation menu",
+      );
       document
         .getElementById("mobile-menu")
         ?.classList.toggle("hidden", expanded);

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -58,4 +58,13 @@ import logo from "../assets/logo.png";
         .getElementById("mobile-menu")
         ?.classList.toggle("hidden", expanded);
     });
+  document.querySelectorAll("button[data-nav-toggle]").forEach((btn) => {
+    const listId = btn.getAttribute("aria-controls");
+    const list = listId && document.getElementById(listId);
+    btn.addEventListener("click", () => {
+      const expanded = btn.getAttribute("aria-expanded") === "true";
+      btn.setAttribute("aria-expanded", String(!expanded));
+      list?.classList.toggle("hidden", expanded);
+    });
+  });
 </script>

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -20,7 +20,7 @@ const {
 ---
 
 <Layout title={title ?? heading}>
-  <article class="prose mx-auto max-w-[48rem]">
+  <article class="prose mx-auto max-w-[48rem] px-4 sm:px-6">
     {heading && <h1 class="my-4 text-3xl font-bold">{heading}</h1>}
     {description && <p class="mb-8 text-lg text-muted">{description}</p>}
     <slot />

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -20,7 +20,7 @@ const {
 ---
 
 <Layout title={title ?? heading}>
-  <article class="prose mx-auto max-w-[48rem] px-4 sm:px-6">
+  <article class="prose mx-auto max-w-[48rem] px-4 md:px-0">
     {heading && <h1 class="my-4 text-3xl font-bold">{heading}</h1>}
     {description && <p class="mb-8 text-lg text-muted">{description}</p>}
     <slot />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const pageTitle = title ? `${title} | ${site.name}` : site.name;
     >
       <Navbar />
     </header>
-    <main id="main" class="mx-auto w-full flex-1 px-4 sm:px-6">
+    <main id="main" class="mx-auto w-full flex-1">
       <slot />
     </main>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const pageTitle = title ? `${title} | ${site.name}` : site.name;
     >
       <Navbar />
     </header>
-    <main id="main" class="mx-auto w-full flex-1">
+    <main id="main" class="mx-auto w-full flex-1 px-4 sm:px-6">
       <slot />
     </main>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const pageTitle = title ? `${title} | ${site.name}` : site.name;
 <html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,100 +6,105 @@ import background from "../assets/background.png";
 ---
 
 <Layout title="Further South">
-    <section class="hero">
-      <div class="hero-image">
-        <Image src={background} alt="Further South Mascot" layout="full-width" />
-      </div>
+	<section class="hero">
+		<div class="hero-image">
+			<Image
+				src={background}
+				alt="Further South Mascot"
+				layout="full-width"
+			/>
+		</div>
 
-      <div class="info">
-        <h1>Further South</h1>
-        <p>
-          Further South is an up and coming furry convention celebrating
-          community, art, fursuits, and fun!
-        </p>
-        <p>
-          Hosted in the heart of Portsmouth, surrounded by history, waves and sun
-        </p>
-        <h2>6–9 March</h2>
-        <a
-          class="register"
-          href="https://reg.furthersouth.uk/kiosk/furthersouth"
-          rel="noopener noreferrer"
-        >
-          Register Now
-        </a>
-      </div>
-    </section>
+		<div class="info">
+			<h1>Further South</h1>
+			<p>
+				Further South is an up and coming furry convention celebrating
+				community, art, fursuits, and fun!
+			</p>
+			<p>
+				Hosted in the heart of Portsmouth, surrounded by history, waves
+				and sun
+			</p>
+			<h2 class="font-bold">6–9 March</h2>
+			<a
+				class="register"
+				href="https://reg.furthersouth.uk/kiosk/furthersouth"
+				rel="noopener noreferrer"
+			>
+				Register Now
+			</a>
+		</div>
+	</section>
 </Layout>
 
 <style>
-  .hero {
-    min-height: 100vh;
-    width: 100%;
-    background: linear-gradient(
-      to bottom,
-      #a7f3d0 0%,
-      #3b82f6 50%,
-      #1e3a8a 100%
-    );
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 2rem;
-  }
-  .hero-image {
-    width: 100%;
-    margin: 2rem 0;
-  }
-  .hero-image img {
-    width: 100%;
-    height: auto;
-    border-radius: 1rem;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
-  }
-  .info {
-    width: 100%;
-    max-width: 1200px;
-    background: rgba(255, 255, 255, 0.9);
-    padding: 2rem;
-    border-radius: 1rem;
-    font-size: 1.5rem;
-    line-height: 1.7;
-    text-align: center;
-    margin-top: 1rem;
-  }
-  .register {
-    display: inline-block;
-    font-size: 1.8rem; /* big text */
-    font-weight: 700; /* bold */
-    color: white; /* text color */
-    background: linear-gradient(
-      135deg,
-      #3b82f6,
-      #06b6d4
-    ); /* bright blue → turquoise */
-    padding: 1rem 3rem; /* large clickable area */
-    border: none;
-    border-radius: 1rem; /* rounded corners */
-    cursor: pointer;
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.25);
-    transition:
-      transform 0.2s ease,
-      box-shadow 0.2s ease,
-      background 0.3s ease;
-    margin-top: 1rem;
-  }
-  .register:hover {
-    transform: translateY(-3px); /* subtle lift */
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
-    background: linear-gradient(
-      135deg,
-      #06b6d4,
-      #3b82f6
-    ); /* gradient swap for effect */
-  }
-  .register:active {
-    transform: translateY(1px); /* pressed effect */
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-  }
+	.hero {
+		min-height: 100vh;
+		width: 100%;
+		background: linear-gradient(
+			to bottom,
+			#a7f3d0 0%,
+			#3b82f6 50%,
+			#1e3a8a 100%
+		);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 2rem;
+	}
+	.hero-image {
+		width: 100%;
+		margin: 2rem 0;
+	}
+	.hero-image img {
+		width: 100%;
+		height: auto;
+		border-radius: 1rem;
+		box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+	}
+	.info {
+		width: 100%;
+		max-width: 1200px;
+		background: rgba(255, 255, 255, 0.9);
+		padding: 2rem;
+		border-radius: 1rem;
+		font-size: 1.5rem;
+		line-height: 1.7;
+		text-align: center;
+		margin-top: 1rem;
+	}
+	.register {
+		display: inline-block;
+		font-size: 1.8rem; /* big text */
+		font-weight: 700; /* bold */
+		color: white; /* text color */
+		background: linear-gradient(
+			135deg,
+			#3b82f6,
+			#06b6d4
+		); /* bright blue → turquoise */
+		padding: 1rem 3rem; /* large clickable area */
+		border: none;
+		border-radius: 1rem; /* rounded corners */
+		cursor: pointer;
+		box-shadow: 0 6px 15px rgba(0, 0, 0, 0.25);
+		transition:
+			transform 0.2s ease,
+			box-shadow 0.2s ease,
+			background 0.3s ease;
+		margin-top: 1rem;
+	}
+	.register:hover {
+		transform: translateY(-3px); /* subtle lift */
+		box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+		background: linear-gradient(
+			135deg,
+			#06b6d4,
+			#3b82f6
+		); /* gradient swap for effect */
+	}
+	.register:active {
+		transform: translateY(1px); /* pressed effect */
+		box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+	}
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,27 +6,30 @@ import background from "../assets/background.png";
 ---
 
 <Layout title="Further South">
-  <section class="hero">
-    <div class="hero-image">
-      <Image src={background} alt="Further South Mascot" layout="full-width" />
-    </div>
+    <section class="hero">
+      <div class="hero-image">
+        <Image src={background} alt="Further South Mascot" layout="full-width" />
+      </div>
 
-    <div class="info">
-      <p>
-        Further South is an up and coming furry convention celebrating
-        community, art, fursuits, and fun!
-      </p>
-      <hr />
-      <p>
-        Hosted in the heart of Portsmouth, surrounded by history, waves and sun
-      </p>
-      <hr />
-      <p><b>6-9th</b> March</p>
-      <hr />
-      <p><b> <u> REGISTER NOW </u> </b></p>
-      <button class="register"> Register </button>
-    </div>
-  </section>
+      <div class="info">
+        <h1>Further South</h1>
+        <p>
+          Further South is an up and coming furry convention celebrating
+          community, art, fursuits, and fun!
+        </p>
+        <p>
+          Hosted in the heart of Portsmouth, surrounded by history, waves and sun
+        </p>
+        <h2>6–9 March</h2>
+        <a
+          class="register"
+          href="https://reg.furthersouth.uk/kiosk/furthersouth"
+          rel="noopener noreferrer"
+        >
+          Register Now
+        </a>
+      </div>
+    </section>
 </Layout>
 
 <style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,105 +6,100 @@ import background from "../assets/background.png";
 ---
 
 <Layout title="Further South">
-	<section class="hero">
-		<div class="hero-image">
-			<Image
-				src={background}
-				alt="Further South Mascot"
-				layout="full-width"
-			/>
-		</div>
+  <section class="hero">
+    <div class="hero-image">
+      <Image src={background} alt="Further South Mascot" layout="full-width" />
+    </div>
 
-		<div class="info">
-			<h1>Further South</h1>
-			<p>
-				Further South is an up and coming furry convention celebrating
-				community, art, fursuits, and fun!
-			</p>
-			<p>
-				Hosted in the heart of Portsmouth, surrounded by history, waves
-				and sun
-			</p>
-			<h2 class="font-bold">6–9 March</h2>
-			<a
-				class="register"
-				href="https://reg.furthersouth.uk/kiosk/furthersouth"
-				rel="noopener noreferrer"
-			>
-				Register Now
-			</a>
-		</div>
-	</section>
+    <div class="info">
+      <h1>Further South</h1>
+      <p>
+        Further South is an up and coming furry convention celebrating
+        community, art, fursuits, and fun!
+      </p>
+      <p>
+        Hosted in the heart of Portsmouth, surrounded by history, waves and sun
+      </p>
+      <h2 class="font-bold">6–9 March</h2>
+      <a
+        class="register"
+        href="https://reg.furthersouth.uk/kiosk/furthersouth"
+        rel="noopener noreferrer"
+      >
+        Register Now
+      </a>
+    </div>
+  </section>
 </Layout>
 
 <style>
-	.hero {
-		min-height: 100vh;
-		width: 100%;
-		background: linear-gradient(
-			to bottom,
-			#a7f3d0 0%,
-			#3b82f6 50%,
-			#1e3a8a 100%
-		);
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		padding: 2rem;
-	}
-	.hero-image {
-		width: 100%;
-		margin: 2rem 0;
-	}
-	.hero-image img {
-		width: 100%;
-		height: auto;
-		border-radius: 1rem;
-		box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
-	}
-	.info {
-		width: 100%;
-		max-width: 1200px;
-		background: rgba(255, 255, 255, 0.9);
-		padding: 2rem;
-		border-radius: 1rem;
-		font-size: 1.5rem;
-		line-height: 1.7;
-		text-align: center;
-		margin-top: 1rem;
-	}
-	.register {
-		display: inline-block;
-		font-size: 1.8rem; /* big text */
-		font-weight: 700; /* bold */
-		color: white; /* text color */
-		background: linear-gradient(
-			135deg,
-			#3b82f6,
-			#06b6d4
-		); /* bright blue → turquoise */
-		padding: 1rem 3rem; /* large clickable area */
-		border: none;
-		border-radius: 1rem; /* rounded corners */
-		cursor: pointer;
-		box-shadow: 0 6px 15px rgba(0, 0, 0, 0.25);
-		transition:
-			transform 0.2s ease,
-			box-shadow 0.2s ease,
-			background 0.3s ease;
-		margin-top: 1rem;
-	}
-	.register:hover {
-		transform: translateY(-3px); /* subtle lift */
-		box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
-		background: linear-gradient(
-			135deg,
-			#06b6d4,
-			#3b82f6
-		); /* gradient swap for effect */
-	}
-	.register:active {
-		transform: translateY(1px); /* pressed effect */
-		box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-	}
+  .hero {
+    min-height: 100vh;
+    width: 100%;
+    background: linear-gradient(
+      to bottom,
+      #a7f3d0 0%,
+      #3b82f6 50%,
+      #1e3a8a 100%
+    );
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem;
+  }
+  .hero-image {
+    width: 100%;
+    margin: 2rem 0;
+  }
+  .hero-image img {
+    width: 100%;
+    height: auto;
+    border-radius: 1rem;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  }
+  .info {
+    width: 100%;
+    max-width: 1200px;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 2rem;
+    border-radius: 1rem;
+    font-size: 1.5rem;
+    line-height: 1.7;
+    text-align: center;
+    margin-top: 1rem;
+  }
+  .register {
+    display: inline-block;
+    font-size: 1.8rem; /* big text */
+    font-weight: 700; /* bold */
+    color: white; /* text color */
+    background: linear-gradient(
+      135deg,
+      #3b82f6,
+      #06b6d4
+    ); /* bright blue → turquoise */
+    padding: 1rem 3rem; /* large clickable area */
+    border: none;
+    border-radius: 1rem; /* rounded corners */
+    cursor: pointer;
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.25);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      background 0.3s ease;
+    margin-top: 1rem;
+  }
+  .register:hover {
+    transform: translateY(-3px); /* subtle lift */
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+    background: linear-gradient(
+      135deg,
+      #06b6d4,
+      #3b82f6
+    ); /* gradient swap for effect */
+  }
+  .register:active {
+    transform: translateY(1px); /* pressed effect */
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  }
 </style>


### PR DESCRIPTION
## Summary
- add hamburger mobile navigation with collapsible menu entries
- filter out index pages and support accordion-style submenus

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a95c3df32c832489205641783e4e4a