### PR TITLE
Add `assets` path to tsconfig, update background+logo paths

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,7 +2,7 @@
 import { Image } from "astro:assets";
 import { site } from "../data/site";
 import NavMenu from "./NavMenu.astro";
-import logo from "../assets/logo.png";
+import logo from "@assets/logo.png";
 import { Menu } from "lucide-astro";
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 // src/pages/index.astro
 import Layout from "../layouts/Layout.astro";
 import { Image } from "astro:assets";
-import background from "../assets/background.png";
+import background from "@assets/background.png";
 ---
 
 <Layout title="Further South">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@assets/*": ["src/assets/*"]
+    }
+  }
 }


### PR DESCRIPTION
Add `assets` path to tsconfig for image imports in place of explicit path resolution. 

Will be useful when we add high quality assets from da server :)